### PR TITLE
Add custom attribute to handle permanent elements rendered with morphdom

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -11,7 +11,7 @@ document.addEventListener("turbo:before-render", (event) => {
     await new Promise((resolve) => setTimeout(() => resolve(), 0));
     morphdom(prevEl, newEl, {
       onBeforeElUpdated(fromEl, toEl) {
-        if (fromEl === toEl) return false;
+        if (fromEl.isEqualNode(toEl)) return false;
 
         return !fromEl.hasAttribute('data-turbo-permanent-morphdom');
       }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,7 +9,13 @@ document.addEventListener("turbo:before-render", (event) => {
   prevPath = window.location.pathname;
   event.detail.render = async (prevEl, newEl) => {
     await new Promise((resolve) => setTimeout(() => resolve(), 0));
-    morphdom(prevEl, newEl);
+    morphdom(prevEl, newEl, {
+      onBeforeElUpdated(fromEl, toEl) {
+        if (fromEl === toEl) return false;
+
+        return !fromEl.hasAttribute('data-turbo-permanent-morphdom');
+      }
+    });
   };
 
   if (document.startViewTransition) {

--- a/app/views/albums/_aside.html.erb
+++ b/app/views/albums/_aside.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (album: nil) -%>
-<%= turbo_frame_tag :aside, class: "aside", target: "_top", data: {"turbo-permanent" => true}, "transition-name" => "aside" do %>
+<%= turbo_frame_tag :aside, class: "aside", target: "_top", data: {"turbo-permanent-morphdom" => true}, "transition-name" => "aside" do %>
   <% next unless album %>
   <div transition-id="<%= album.id %>">
     <div class="album-info">

--- a/app/views/shared/_player.html.erb
+++ b/app/views/shared/_player.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (track:, station: nil) -%>
-<div class="player" id="<%= dom_id(station || track, "player_#{track.id}") %>" data-turbo-permanent>
+<div class="player" id="<%= dom_id(station || track, "player_#{track.id}") %>" data-turbo-permanent-morphdom>
   <% if track %>
     <div class="player--timeline">
       <div class="player--timeline-progress" style="width:11%;"></div>


### PR DESCRIPTION
## Задание

Необходимо перенести логику перманентных элементов из Turbo в morphdom и сделать так, чтобы элементы остались в DOM-дереве, если нет необходимости их перерисовывать.

## Критерии выполнения

- [x] Прогресс-бар плеера не прерывается при навигации по приложению
- [x] Прогресс-бар стартует заново при смене трека в плеера

## Комментарии

Не могу сказать, что полностью разобрался в вопросе... Без замены атрибута в компоненте `aside` навигация на главную страницу по ссылке в шапке сбрасывала прогресс плейера. С заменой кое-как работает, но теперь текущий трек не отображается  