### PR TITLE
Artist tracks page with infinite scroll

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,5 +1,5 @@
 class TracksController < ApplicationController
-  helper_method :current_page, :next_page
+  helper_method :current_page, :next_page, :per_page
 
   def index
     @artist = Artist.find(params[:artist_id])

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,7 +1,32 @@
 class TracksController < ApplicationController
-  def index
-    artist = Artist.find(params[:artist_id])
+  helper_method :current_page, :has_next_page?, :next_page
 
-    render action: :index, locals: {artist:}
+  def index
+    @artist = Artist.find(params[:artist_id])
+    tracks = @artist.tracks.offset(current_page * per_page).limit(per_page)
+
+    if turbo_frame_request? && turbo_frame_request_id.include?("tracks")
+      render partial: "tracks", locals: {artist: @artist, tracks:}
+    else
+      render action: :index, locals: {artist: @artist, tracks:}
+    end
+  end
+
+  private
+
+  def per_page
+    10
+  end
+
+  def current_page
+    (params[:page] || 1).to_i
+  end
+
+  def has_next_page?
+    current_page * 10 < @artist.tracks.size
+  end
+
+  def next_page
+    current_page + 1
   end
 end

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,0 +1,7 @@
+class TracksController < ApplicationController
+  def index
+    artist = Artist.find(params[:artist_id])
+
+    render action: :index, locals: {artist:}
+  end
+end

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,12 +1,12 @@
 class TracksController < ApplicationController
-  helper_method :current_page, :has_next_page?, :next_page
+  helper_method :current_page, :next_page
 
   def index
     @artist = Artist.find(params[:artist_id])
     tracks = @artist.tracks.offset(current_page * per_page).limit(per_page)
 
     if turbo_frame_request? && turbo_frame_request_id.include?("tracks")
-      render partial: "tracks", locals: {artist: @artist, tracks:}
+      render partial: "tracks", locals: {artist: @artist, tracks:, current_page:, next_page:}
     else
       render action: :index, locals: {artist: @artist, tracks:}
     end
@@ -23,10 +23,10 @@ class TracksController < ApplicationController
   end
 
   def has_next_page?
-    current_page * 10 < @artist.tracks.size
+    current_page * per_page < @artist.tracks.size
   end
 
   def next_page
-    current_page + 1
+    current_page + 1 if has_next_page?
   end
 end

--- a/app/views/artists/_artist_info.html.erb
+++ b/app/views/artists/_artist_info.html.erb
@@ -1,0 +1,18 @@
+<%# locals: (artist:) -%>
+<div class="artist-header">
+  <div class="artist-image">
+    <% if artist.cover.attached? %>
+      <%= image_tag artist.cover %>
+    <% end %>
+  </div>
+  <div class="artist-info">
+    <div class="flex items-center">
+      <h1 class="text-header-2"><%= artist.name %></h1>
+    </div>
+    <div>
+      <% artist.tags.each do |tag| %>
+        <span class="meta"><%= tag %></span>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -1,20 +1,4 @@
-<div class="artist-header">
-  <div class="artist-image">
-    <% if artist.cover.attached? %>
-      <%= image_tag artist.cover %>
-    <% end %>
-  </div>
-  <div class="artist-info">
-    <div class="flex items-center">
-      <h1 class="text-header-2"><%= artist.name %></h1>
-    </div>
-    <div>
-      <% artist.tags.each do |tag| %>
-        <span class="meta"><%= tag %></span>
-      <% end %>
-    </div>
-  </div>
-</div>
+<%= render partial: "artist_info", locals: {artist:} %>
 
 <hr class="my-4">
 

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -18,7 +18,10 @@
 
 <hr class="my-4">
 
-<h2 class="mt-4 text-header-2">Popular</h2>
+<div class="flex items-baseline justify-between">
+  <h2 class="text-header-2">Popular</h2>
+  <%= link_to "See all", "#", class: "text-secondary hover:text-primary transition-colors text-sm" %>
+</div>
 <ul class="tracks mt-2">
   <%= render tracks, enqueueble: true %>
   <li class="track">

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -20,7 +20,7 @@
 
 <div class="flex items-baseline justify-between">
   <h2 class="text-header-2">Popular</h2>
-  <%= link_to "See all", "#", class: "text-secondary hover:text-primary transition-colors text-sm" %>
+  <%= link_to "See all", artist_tracks_path(artist), class: "text-secondary hover:text-primary transition-colors text-sm" %>
 </div>
 <ul class="tracks mt-2">
   <%= render tracks, enqueueble: true %>

--- a/app/views/tracks/_track.html.erb
+++ b/app/views/tracks/_track.html.erb
@@ -1,10 +1,10 @@
-<%# locals: (track:, track_counter: nil, track_iteration: nil, deletable: false, enqueueble: false) -%>
+<%# locals: (track:, track_counter: nil, track_iteration: nil, deletable: false, enqueueble: false, starting_index: 0) -%>
 <li class="track">
   <span class="track--number">
     <% if track.id == current_track&.id %>
       <span class="track--number--text track--playing-indicator"></span>
     <% else %>
-      <%= track_counter + 1 %>
+      <%= starting_index + track_counter + 1 %>
     <% end %>
   </span>
   <% if current_user&.live_station&.live? %>

--- a/app/views/tracks/_tracks.html.erb
+++ b/app/views/tracks/_tracks.html.erb
@@ -1,12 +1,6 @@
 <%# locals: (artist:, tracks:, current_page: 0, next_page: nil) -%>
 <%= turbo_frame_tag dom_id(artist, "tracks_page_#{current_page}") do %>
-  <% tracks.each.with_index do |track, i| %>
-    <%=
-      render track,
-        enqueueble: true,
-        track_counter: (current_page - 1) * 10 + i
-    %>
-  <% end %>
+  <%= render tracks, enqueueble: true, starting_index: (current_page - 1) * per_page %>
 
   <% unless next_page.nil? %>
     <%= turbo_frame_tag dom_id(artist, "tracks_page_#{next_page}"), src: artist_tracks_path(artist, page: next_page), loading: :lazy %>

--- a/app/views/tracks/_tracks.html.erb
+++ b/app/views/tracks/_tracks.html.erb
@@ -1,0 +1,8 @@
+<%# locals: (artist:, tracks:) -%>
+<%= turbo_frame_tag dom_id(artist, "tracks_page_#{current_page}") do %>
+  <%= render tracks, enqueueble: true %>
+
+  <% if has_next_page? %>
+    <%= turbo_frame_tag dom_id(artist, "tracks_page_#{next_page}"), src: artist_tracks_path(artist, page: next_page), loading: :lazy %>
+  <% end %>
+<% end %>

--- a/app/views/tracks/_tracks.html.erb
+++ b/app/views/tracks/_tracks.html.erb
@@ -1,6 +1,12 @@
 <%# locals: (artist:, tracks:, current_page: 0, next_page: nil) -%>
 <%= turbo_frame_tag dom_id(artist, "tracks_page_#{current_page}") do %>
-  <%= render tracks, enqueueble: true %>
+  <% tracks.each.with_index do |track, i| %>
+    <%=
+      render track,
+        enqueueble: true,
+        track_counter: (current_page - 1) * 10 + i
+    %>
+  <% end %>
 
   <% unless next_page.nil? %>
     <%= turbo_frame_tag dom_id(artist, "tracks_page_#{next_page}"), src: artist_tracks_path(artist, page: next_page), loading: :lazy %>

--- a/app/views/tracks/_tracks.html.erb
+++ b/app/views/tracks/_tracks.html.erb
@@ -1,8 +1,8 @@
-<%# locals: (artist:, tracks:) -%>
+<%# locals: (artist:, tracks:, current_page: 0, next_page: nil) -%>
 <%= turbo_frame_tag dom_id(artist, "tracks_page_#{current_page}") do %>
   <%= render tracks, enqueueble: true %>
 
-  <% if has_next_page? %>
+  <% unless next_page.nil? %>
     <%= turbo_frame_tag dom_id(artist, "tracks_page_#{next_page}"), src: artist_tracks_path(artist, page: next_page), loading: :lazy %>
   <% end %>
 <% end %>

--- a/app/views/tracks/index.html.erb
+++ b/app/views/tracks/index.html.erb
@@ -7,5 +7,5 @@
 </h2>
 
 <ul>
-  <%= render partial: "tracks", locals: {artist:, tracks:} %>
+  <%= render partial: "tracks", locals: {artist:, tracks:, current_page:, next_page:} %>
 </ul>

--- a/app/views/tracks/index.html.erb
+++ b/app/views/tracks/index.html.erb
@@ -5,3 +5,7 @@
 <h2 class="text-header-2">
   Tracks
 </h2>
+
+<ul>
+  <%= render partial: "tracks", locals: {artist:, tracks:} %>
+</ul>

--- a/app/views/tracks/index.html.erb
+++ b/app/views/tracks/index.html.erb
@@ -1,0 +1,23 @@
+<div class="artist-header">
+  <div class="artist-image">
+    <% if artist.cover.attached? %>
+      <%= image_tag artist.cover %>
+    <% end %>
+  </div>
+  <div class="artist-info">
+    <div class="flex items-center">
+      <h1 class="text-header-2"><%= artist.name %></h1>
+    </div>
+    <div>
+      <% artist.tags.each do |tag| %>
+        <span class="meta"><%= tag %></span>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<hr class="my-4">
+
+<h2 class="text-header-2">
+  Tracks
+</h2>

--- a/app/views/tracks/index.html.erb
+++ b/app/views/tracks/index.html.erb
@@ -1,20 +1,4 @@
-<div class="artist-header">
-  <div class="artist-image">
-    <% if artist.cover.attached? %>
-      <%= image_tag artist.cover %>
-    <% end %>
-  </div>
-  <div class="artist-info">
-    <div class="flex items-center">
-      <h1 class="text-header-2"><%= artist.name %></h1>
-    </div>
-    <div>
-      <% artist.tags.each do |tag| %>
-        <span class="meta"><%= tag %></span>
-      <% end %>
-    </div>
-  </div>
-</div>
+<%= render partial: "artists/artist_info", locals: {artist:} %>
 
 <hr class="my-4">
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
   post "sign_up", to: "registrations#create"
   delete "sign_out", to: "sessions#destroy", as: :sign_out
 
-  resources :artists, only: [:show]
+  resources :artists, only: [:show] do
+    resources :tracks, only: [:index]
+  end
+
   resources :albums, only: [:show] do
     patch :play, on: :member
   end


### PR DESCRIPTION
## Задание

Необходимо добавить новую страницу со всеми треками артиста с ленивой подгрузкой треков при прокрутке (aka infinite scroll pagination). Использовать только Turbo Frames.

## Критерии выполнения

Напротив "Popular tracks" на странице артиста необходимо добавить ссылку "See all".
При клике на неё открывается страница /artists/:id/tracks, на которой выводится список всех треков.
Работает как на примере ниже.

## Комментарии

1. При таком подходе с `ul/li` HTML не выглядит валидным, т.к. каждая страница обернута в `turbo-frame`. Однако удобно.
2. Вычислять номер трэка в списке руками странно. Какой вариант был бы красивее?
3. Прокрутка страницы рябит.