### PR TITLE
Allow play and pause live station

### DIFF
--- a/app/assets/stylesheets/player.css
+++ b/app/assets/stylesheets/player.css
@@ -16,15 +16,15 @@
   @apply cursor-pointer;
 }
 
-.player-playing .player-btn[data-action="click->player#play"] {
+.player-playing .player-btn[data-role="play-button"] {
   @apply hidden;
 }
 
-.player-btn[data-action="click->player#pause"] {
+.player-btn[data-role="pause-button"] {
   @apply hidden;
 }
 
-.player-playing .player-btn[data-action="click->player#pause"] {
+.player-playing .player-btn[data-role="pause-button"] {
   @apply block;
 }
 

--- a/app/commands/player_command.rb
+++ b/app/commands/player_command.rb
@@ -17,4 +17,18 @@ class PlayerCommand < ApplicationCommand
       turbo_stream.update("player", partial: "player/player", locals: {track:})
     end
   end
+
+  def pause
+    station = current_user.live_station
+    track = station.current_track
+
+    turbo_stream.update("player", partial: "player/player", locals: {track:, station:, live: false})
+  end
+
+  def resume
+    station = current_user.live_station
+    track = station.current_track
+
+    turbo_stream.update("player", partial: "player/player", locals: {track:, station:, live: true})
+  end
 end

--- a/app/javascript/controllers/player_controller.js
+++ b/app/javascript/controllers/player_controller.js
@@ -14,7 +14,7 @@ function secondsToDuration(num) {
 export default class extends Controller {
   static targets = ["progress", "time"];
   static outlets = ["track"];
-  static values = { duration: Number, track: String, nextTrackUrl: String };
+  static values = { duration: Number, track: String, nextTrackUrl: String, station: Number, stationLive: Boolean };
   static classes = ["playing"];
 
   initialize() {
@@ -125,5 +125,15 @@ export default class extends Controller {
   removeAudioListeners() {
     this.audio.removeEventListener("timeupdate", this.handleTimeUpdate);
     this.audio.removeEventListener("ended", this.handleEnded);
+  }
+
+  stationLiveValueChanged() {
+    if (!this.stationValue) return;
+
+    if (this.stationLiveValue) {
+      this.play();
+    } else {
+      this.pause();
+    }
   }
 }

--- a/app/views/player/_player.html.erb
+++ b/app/views/player/_player.html.erb
@@ -6,6 +6,8 @@
   data-player-playing-class="player-playing"
   data-player-next-track-url-value="<%= live ? play_next_live_station_path : (!station && play_next_track_path(track))%>"
   data-player-track-outlet=".track"
+  data-player-station-value="<%= station&.id %>"
+  data-player-station-live-value="<%= live %>"
 >
   <% if track %>
     <div class="player--timeline" data-action="<%= "click->player#seek" if live || !station %>">
@@ -26,10 +28,10 @@
 
   <% if station %>
     <div class="player--controls">
-      <%= button_to "#", method: :post, class: "player-btn", form: {data: {"turbo-command" => "PlayerCommand#resume"}} do %>
+      <%= button_to "#", method: :post, class: "player-btn", form: {data: {"turbo-command" => "PlayerCommand#resume"}}, data: { role: "play-button" } do %>
         <%= render "icons/play" %>
       <% end %>
-      <%= button_to "#", method: :post, class: "player-btn", form: {data: {"turbo-command" => "PlayerCommand#pause"}} do %>
+      <%= button_to "#", method: :post, class: "player-btn", form: {data: {"turbo-command" => "PlayerCommand#pause"}}, data: { role: "pause-button" } do %>
         <%= render "icons/pause" %>
       <% end %>
     </div>

--- a/app/views/player/_player.html.erb
+++ b/app/views/player/_player.html.erb
@@ -12,12 +12,13 @@
       <div class="player--timeline-progress" style="width:0%;" data-player-target="progress"></div>
     </div>
   <% end %>
+
   <% unless station %>
   <div class="player--controls">
-    <span class="player-btn" data-action="click->player#play">
+    <span class="player-btn" data-action="click->player#play" data-role="play-button">
       <%= render "icons/play" %>
     </span>
-    <span class="player-btn" data-action="click->player#pause">
+    <span class="player-btn" data-action="click->player#pause" data-role="pause-button">
       <%= render "icons/pause" %>
     </span>
   </div>

--- a/app/views/player/_player.html.erb
+++ b/app/views/player/_player.html.erb
@@ -22,6 +22,18 @@
     </span>
   </div>
   <% end %>
+
+  <% if station %>
+    <div class="player--controls">
+      <%= button_to "#", method: :post, class: "player-btn", form: {data: {"turbo-command" => "PlayerCommand#resume"}} do %>
+        <%= render "icons/play" %>
+      <% end %>
+      <%= button_to "#", method: :post, class: "player-btn", form: {data: {"turbo-command" => "PlayerCommand#pause"}} do %>
+        <%= render "icons/pause" %>
+      <% end %>
+    </div>
+  <% end %>
+
   <div class="player--track">
     <% if station %>
       <% if live %>


### PR DESCRIPTION
## Задача

Добавить возможность автору трансляции ставить проигрывание трека на паузу (и обратно) и синхронизировать эти действия со слушателями.

## Критерии выполнения

Вернуть кнопки управления воспроизведением в плеер в состоянии трансляции.
При клике транслирующим на play/pause соответствующее действие должно отправляться слушателям.

## Комментарии

Не смог воспользоваться TurboPower. Вроде все по мануалу делаю, но сначала все сыпется на CSRF токенах, а потом на роутере. Возможно все дело в версии библиотеки. В TurboBoost она 0.0.11, у TurboPower 0.0.8. Без нее вроде тоже понял что к чему, только с прогрессом текущего трека не заморочился.