### PR TITLE
Listeners count

### DIFF
--- a/app/assets/stylesheets/player.css
+++ b/app/assets/stylesheets/player.css
@@ -89,3 +89,19 @@
   @apply text-secondary;
   animation: pulse 1s infinite;
 }
+
+.player--listeners {
+  @apply text-white text-small w-full flex flex-row items-center bg-primary rounded-md ml-2 px-1;
+}
+
+.player--listeners--icon {
+  @apply text-white flex items-center;
+}
+
+.player--listeners--icon > svg {
+  @apply h-5;
+}
+
+.player--listeners--count {
+  @apply mx-1 font-semibold;
+}

--- a/app/channels/application_channel.rb
+++ b/app/channels/application_channel.rb
@@ -1,0 +1,2 @@
+class ApplicationChannel < ApplicationCable::Channel
+end

--- a/app/channels/application_channel.rb
+++ b/app/channels/application_channel.rb
@@ -1,2 +1,6 @@
 class ApplicationChannel < ApplicationCable::Channel
+  extend Turbo::Streams::Broadcasts
+  extend Turbo::Streams::StreamName
+  include Turbo::Streams::StreamName::ClassMethods
+  include ActionView::RecordIdentifier
 end

--- a/app/channels/application_channel.rb
+++ b/app/channels/application_channel.rb
@@ -1,6 +1,3 @@
-class ApplicationChannel < ApplicationCable::Channel
-  extend Turbo::Streams::Broadcasts
-  extend Turbo::Streams::StreamName
-  include Turbo::Streams::StreamName::ClassMethods
+class ApplicationChannel < Turbo::StreamsChannel
   include ActionView::RecordIdentifier
 end

--- a/app/channels/live_station_channel.rb
+++ b/app/channels/live_station_channel.rb
@@ -1,9 +1,17 @@
 class LiveStationChannel < ApplicationChannel
   def subscribed
-    puts "hello"
+    station.increment_listeners_count
+    puts "There are #{station.listeners_count} listeners on #{station.name}"
   end
 
   def unsubscribed
-    puts "goodbye"
+    station.decrement_listeners_count
+    puts "There are #{station.listeners_count} listeners on #{station.name}"
+  end
+
+  private
+
+  def station
+    @station ||= LiveStation.find(params[:station_id])
   end
 end

--- a/app/channels/live_station_channel.rb
+++ b/app/channels/live_station_channel.rb
@@ -1,0 +1,9 @@
+class LiveStationChannel < ApplicationChannel
+  def subscribed
+    puts "hello"
+  end
+
+  def unsubscribed
+    puts "goodbye"
+  end
+end

--- a/app/channels/live_station_channel.rb
+++ b/app/channels/live_station_channel.rb
@@ -1,19 +1,20 @@
 class LiveStationChannel < ApplicationChannel
-  delegate :broadcast_replace_to, to: :"Turbo::StreamsChannel"
+  delegate :broadcast_replace_to, to: :"self.class"
 
-  def subscribed
-    stream_for station
+  after_subscribe :increment_listeners_count
+  after_unsubscribe :decrement_listeners_count
 
+  private
+
+  def increment_listeners_count
     station.increment_listeners_count
     broadcast_replace_to station, target: dom_id(station, :listeners_count), partial: "player/listeners_count", locals: {station: station}
   end
 
-  def unsubscribed
+  def decrement_listeners_count
     station.decrement_listeners_count
     broadcast_replace_to station, target: dom_id(station, :listeners_count), partial: "player/listeners_count", locals: {station: station}
   end
-
-  private
 
   def station
     @station ||= LiveStation.find(params[:station_id])

--- a/app/channels/live_station_channel.rb
+++ b/app/channels/live_station_channel.rb
@@ -1,12 +1,16 @@
 class LiveStationChannel < ApplicationChannel
+  delegate :broadcast_replace_to, to: :"Turbo::StreamsChannel"
+
   def subscribed
+    stream_for station
+
     station.increment_listeners_count
-    puts "There are #{station.listeners_count} listeners on #{station.name}"
+    broadcast_replace_to station, target: dom_id(station, :listeners_count), partial: "player/listeners_count", locals: {station: station}
   end
 
   def unsubscribed
     station.decrement_listeners_count
-    puts "There are #{station.listeners_count} listeners on #{station.name}"
+    broadcast_replace_to station, target: dom_id(station, :listeners_count), partial: "player/listeners_count", locals: {station: station}
   end
 
   private

--- a/app/models/live_station.rb
+++ b/app/models/live_station.rb
@@ -35,4 +35,22 @@ class LiveStation < ApplicationRecord
   end
 
   def current_track = tracks.first
+
+  def listeners_count
+    Rails.cache.fetch(listeners_cache_key, expires_in: 1.minute) { 0 }
+  end
+
+  def increment_listeners_count
+    Rails.cache.increment listeners_cache_key
+  end
+
+  def decrement_listeners_count
+    Rails.cache.decrement listeners_cache_key
+  end
+
+  private
+
+  def listeners_cache_key
+    [:live_station, self, :listeners]
+  end
 end

--- a/app/views/player/_listeners_count.html.erb
+++ b/app/views/player/_listeners_count.html.erb
@@ -1,0 +1,4 @@
+<%# locals: (station:) -%>
+<div id="<%= dom_id(station, :listeners_count) %>">
+  <span class="player--listeners--count"><%= station.listeners_count %></span>
+</div>

--- a/app/views/player/_player.html.erb
+++ b/app/views/player/_player.html.erb
@@ -30,6 +30,15 @@
             <%= render "icons/signal" %>
           </span>
           <%= link_to "Live!", live_station_path, class: "player--title ml-2" %>
+
+          <span class="player--listeners">
+            <span class="player--listeners--icon">
+             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+                <path fill-rule="evenodd" d="M18.685 19.097A9.723 9.723 0 0021.75 12c0-5.385-4.365-9.75-9.75-9.75S2.25 6.615 2.25 12a9.723 9.723 0 003.065 7.097A9.716 9.716 0 0012 21.75a9.716 9.716 0 006.685-2.653zm-12.54-1.285A7.486 7.486 0 0112 15a7.486 7.486 0 015.855 2.812A8.224 8.224 0 0112 20.25a8.224 8.224 0 01-5.855-2.438zM15.75 9a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" clip-rule="evenodd" />
+              </svg>
+            </span>
+            <span class="player--listeners--count">3</span>
+          </span>
         </div>
       <% else %>
         <div class="player--radio">

--- a/app/views/player/_player.html.erb
+++ b/app/views/player/_player.html.erb
@@ -41,6 +41,7 @@
           </span>
         </div>
         <%= turbo_stream_from station, channel: LiveStationChannel, data: { station_id: station.id } %>
+        <%= turbo_stream_from station %>
       <% else %>
         <div class="player--radio">
           <%= render "icons/radio" %>

--- a/app/views/player/_player.html.erb
+++ b/app/views/player/_player.html.erb
@@ -40,7 +40,7 @@
             <span class="player--listeners--count">3</span>
           </span>
         </div>
-        <%= turbo_stream_from station, channel: LiveStationChannel %>
+        <%= turbo_stream_from station, channel: LiveStationChannel, data: { station_id: station.id } %>
       <% else %>
         <div class="player--radio">
           <%= render "icons/radio" %>

--- a/app/views/player/_player.html.erb
+++ b/app/views/player/_player.html.erb
@@ -37,7 +37,7 @@
                 <path fill-rule="evenodd" d="M18.685 19.097A9.723 9.723 0 0021.75 12c0-5.385-4.365-9.75-9.75-9.75S2.25 6.615 2.25 12a9.723 9.723 0 003.065 7.097A9.716 9.716 0 0012 21.75a9.716 9.716 0 006.685-2.653zm-12.54-1.285A7.486 7.486 0 0112 15a7.486 7.486 0 015.855 2.812A8.224 8.224 0 0112 20.25a8.224 8.224 0 01-5.855-2.438zM15.75 9a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" clip-rule="evenodd" />
               </svg>
             </span>
-            <span class="player--listeners--count">3</span>
+            <%= render partial: "player/listeners_count", locals: {station:} %>
           </span>
         </div>
         <%= turbo_stream_from station, channel: LiveStationChannel, data: { station_id: station.id } %>

--- a/app/views/player/_player.html.erb
+++ b/app/views/player/_player.html.erb
@@ -41,7 +41,6 @@
           </span>
         </div>
         <%= turbo_stream_from station, channel: LiveStationChannel, data: { station_id: station.id } %>
-        <%= turbo_stream_from station %>
       <% else %>
         <div class="player--radio">
           <%= render "icons/radio" %>

--- a/app/views/player/_player.html.erb
+++ b/app/views/player/_player.html.erb
@@ -40,6 +40,7 @@
             <span class="player--listeners--count">3</span>
           </span>
         </div>
+        <%= turbo_stream_from station, channel: LiveStationChannel %>
       <% else %>
         <div class="player--radio">
           <%= render "icons/radio" %>


### PR DESCRIPTION
## Задача

Добавить в плеер в режиме трансляции отображение числа активных слушателей. При этом каждую сущность плеера считаем уникальным слушателем (даже если этот один и тот же пользователь).

## Критерии выполнения

При включении станции в одном окне браузера, счётчик у транслирующего увеличивается на единицу. При закрытии окна — уменьшается на единицу.
Необходимо использовать Turbo Streams (и никакой работы с Action Cable каналами в JS).

## Комментарии

Изначально пробовал бродкастить изменения через тот же `LiveStationChannel`. В логах вижу изменения счетчика и рендер паршала, но обновление на страницу не приходило. Поменял на стоковый `Turbo::StreamsChannel` и все нормально.

Счетчик слушателей написан без учета уникальности пользователей. Заметил, что иногда в dev приходит 2 сообщения о подписке, поэтому число может быть неправильным.